### PR TITLE
FEAT: Adicionar ordenação ascendente e descendente na API de ranking

### DIFF
--- a/rankedor-de-links/backend/api.py
+++ b/rankedor-de-links/backend/api.py
@@ -1,12 +1,18 @@
 from flask.views import MethodView
-from flask import jsonify
+from flask import jsonify, request
 from controllers import RankingController
 
 
 class RankingAPI(MethodView):
     def get(self):
+        order = request.args.get('order', 'DESC').upper()
+        if order not in ['ASC', 'DESC']:
+            order = 'DESC'
+
         controller = RankingController()
-        resultado, erro = controller.processar()
+        resultado, erro = controller.processar(order=order)
+
         if erro:
             return jsonify({"erro": erro}), 500
+           
         return jsonify(resultado), 200


### PR DESCRIPTION
A API agora aceita o parâmetro de URL 'order=' para controlar a ordem dos resultados

order=DESC: Ordena os links da maior para a menor nota (comportamento padrão).

order=ASC: Ordena os links da menor para a maior nota.