### PR TITLE
test: adiconando testes de estrutura/rating/critérios/link invalido a…

### DIFF
--- a/rankedor-de-links/backend/tests/test_service.py
+++ b/rankedor-de-links/backend/tests/test_service.py
@@ -1,0 +1,25 @@
+import pytest
+from service import LinkService
+
+def test_output_structure():
+    resultado = LinkService.avaliar_link("https://httpbin.org/json", tentativas=1)
+    assert isinstance(resultado, dict)
+    assert "criteria" in resultado
+    assert "rating" in resultado
+
+def test_rating_range():
+    resultado = LinkService.avaliar_link("https://httpbin.org/json", tentativas=1)
+    assert 0 <= resultado["rating"] <= 10
+
+def test_criteria_keys():
+    resultado = LinkService.avaliar_link("https://httpbin.org/json", tentativas=1)
+    expected_keys = {
+        "performance", "timeouts", "consistency", "security", "content",
+        "usability", "reliability", "headers_quality", "rate_limit", "response_size"
+    }
+    assert set(resultado["criteria"].keys()) == expected_keys
+
+def test_invalid_url_timeout():
+    resultado = LinkService.avaliar_link("https://invalid-url-teste-12345.com", tentativas=1)
+    assert isinstance(resultado, dict)
+    assert 0 <= resultado["rating"] <= 10


### PR DESCRIPTION
## O que foi feito

Este PR adiciona 4 testes automatizados para o método `avaliar_link` da classe `LinkService` localizada em `service.py`.

### Testes incluídos:

- Verificação da estrutura de retorno (`dict` com `criteria` e `rating`)
- Verificação do intervalo de nota final (`rating` entre 0 e 10)
- Presença de todos os critérios esperados
- Tratamento de exceção para URLs inválidas (timeouts, DNS, etc.)

### Pasta de testes

Os testes estão localizados em: backend/tests/test_service.py




