### PR TITLE
FEAT: adicionar testes unitários para RankingController

### DIFF
--- a/rankedor-de-links/backend/tests/test_ranking_controller.py
+++ b/rankedor-de-links/backend/tests/test_ranking_controller.py
@@ -1,0 +1,49 @@
+import unittest
+from backend.controllers import RankingController
+
+class TestRankingController(unittest.TestCase):
+
+    def test_definir_status_ok(self):
+        controller = RankingController()
+        dados = [
+            {"rating": 8},
+            {"rating": 7},
+            {"rating": 9}
+        ]
+        resultado = controller.definir_status(dados)
+        self.assertEqual(resultado, "OK")
+
+    def test_definir_status_degraded(self):
+        controller = RankingController()
+        dados = [
+            {"rating": 6},
+            {"rating": 8},
+            {"rating": 7}
+        ]
+        resultado = controller.definir_status(dados)
+        self.assertEqual(resultado, "DEGRADED")
+
+    def test_definir_status_down(self):
+        controller = RankingController()
+        dados = [
+            {"rating": 3},
+            {"rating": 5},
+            {"rating": 6}
+        ]
+        resultado = controller.definir_status(dados)
+        self.assertEqual(resultado, "DOWN")
+
+    def test_ordenar_e_rankear(self):
+        controller = RankingController()
+        dados = [
+            {"rating": 5},
+            {"rating": 9},
+            {"rating": 7}
+        ]
+        resultado = controller.ordenar_e_rankear(dados)
+        self.assertEqual(resultado[0]['rating'], 9)
+        self.assertEqual(resultado[0]['rank'], 1)
+        self.assertEqual(resultado[2]['rank'], 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Descrição
Criação de testes unitários para a classe `RankingController`, localizada em `backend/controllers.py`.

## O que foi feito
- Criado arquivo `test_ranking_controller.py`
- Adicionados testes com padrão AAA para:
  - `definir_status`
  - `ordenar_e_rankear`

## Como testar
Executar os testes com:
```bash
python -m unittest discover tests
