### PR TITLE
FEAT: adicionar testes para rota GET da API

### DIFF
--- a/rankedor-de-links/backend/tests/test_api.py
+++ b/rankedor-de-links/backend/tests/test_api.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+from backend.api import RankingAPI
+from flask import Flask
+
+class TestRankingAPI(unittest.TestCase):
+
+    def setUp(self):
+        # Arrange: cria app e adiciona rota
+        self.app = Flask(__name__)
+        self.app.add_url_rule('/ranking', view_func=RankingAPI.as_view('ranking_api'))
+        self.client = self.app.test_client()
+
+    @patch('backend.api.RankingController')
+    def test_get_success(self, MockController):
+        # Arrange
+        mock_instance = MockController.return_value
+        mock_instance.processar.return_value = ({
+            "status": "OK",
+            "data": [{"url": "http://teste.com", "rating": 8}]
+        }, None)
+
+        # Act
+        response = self.client.get('/ranking')
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("status", response.json)
+        self.assertEqual(response.json["status"], "OK")
+
+    @patch('backend.api.RankingController')
+    def test_get_error(self, MockController):
+        # Arrange
+        mock_instance = MockController.return_value
+        mock_instance.processar.return_value = (None, "Arquivo não encontrado")
+
+        # Act
+        response = self.client.get('/ranking')
+
+        # Assert
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("erro", response.json)
+        self.assertEqual(response.json["erro"], "Arquivo não encontrado")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Descrição
Este PR adiciona testes unitários para a classe `RankingAPI`, definida em `backend/api.py`.

## O que foi feito
- Criado arquivo `test_api.py`
- Testados dois cenários da rota `/ranking`:
  - Sucesso (200 OK)
  - Erro (500 e mensagem)

## Como testar
Executar:
```bash
python -m unittest discover tests
