### PR TITLE
FEAT: corrigido erro de merge e restaurando json do front

### DIFF
--- a/rankedor-de-links/backend/teste.json
+++ b/rankedor-de-links/backend/teste.json
@@ -1,0 +1,17 @@
+[
+  "https://jsonplaceholder.typicode.com/posts",
+  "https://restcountries.com/v3.1/all",
+  "https://thedogapi.com/api/breeds",
+  "https://api.coingecko.com/api/v3/ping",
+  "https://api.spacexdata.com/v4/launches/latest",
+  "https://api.agify.io?name=michael",
+  "https://api.genderize.io?name=luc",
+  "https://api.nationalize.io?name=nathaniel",
+  "https://api.publicapis.org/entries",
+  "https://catfact.ninja/fact",
+  "https://api.chucknorris.io/jokes/random",
+  "https://open.er-api.com/v6/latest/USD",
+  "https://dog.ceo/api/breeds/list/all",
+  "https://api.github.com/repos/python/cpython",
+  "https://datausa.io/api/data?drilldowns=Nation&measures=Population"
+]


### PR DESCRIPTION
O arquivo `api.py` continha marcadores de conflito de merge do Git. Os marcadores foram removidos e o código voltou para sua versão funcional.
A pasta json do back foi restaurada